### PR TITLE
Cast value to string, because null is no longer supported in php8.1

### DIFF
--- a/src/Dflydev/PlaceholderResolver/RegexPlaceholderResolver.php
+++ b/src/Dflydev/PlaceholderResolver/RegexPlaceholderResolver.php
@@ -56,7 +56,7 @@ class RegexPlaceholderResolver extends AbstractPlaceholderResolver
             $newValue = preg_replace_callback(
                 $this->pattern,
                 array($this->placeholderResolverCallback, 'callback'),
-                $value
+                (string)$value
             );
             if ($newValue === $value) { break; }
             $value = $newValue;


### PR DESCRIPTION
This dependency of Sculpin has some PHP deprecation notices in PHP 8.1; this PR may help address the issue.

It might make more sense to remove the dflydev dependencies from sculpin, but that is not currently in the allocated developer time for the project.